### PR TITLE
chore(dev): don't launch dev task with pnpm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "npm.packageManager": "npm",
+}


### PR DESCRIPTION
It seems that VS Code was infering that we're using pnpm and was automatically choosing to launch the npm script `dev` with pnpm. But if that wasn't globally installed on the developer's machine the launch script would fail practically on boot.

This fix explicitly tells VS Code we're using npm as the package manager, a lie, which lets us work around the problem. Hopefully this won't be the cause of other issues down the line \#foreshadowing

Closes #21