### PR TITLE
fix(config): use rad node root url as http endpoint config default

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
           "radicle.advanced.httpApiEndpoint": {
             "scope": "machine-overridable",
             "type": "string",
-            "default": "http://127.0.0.1:8080/api/v1",
+            "default": "http://127.0.0.1:8080",
             "markdownDescription": "Specifies the endpoint to the root of the Radicle HTTP API connected to a seed node. This is commonly served via `radicle-httpd` and can be any Fully-Qualified Domain Name (FQDN) i.e. $protocol://$host:$port/$path ."
           }
         }

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,0 +1,52 @@
+import { fetch } from 'undici'
+import { log } from '../utils'
+import { getConfig } from './config'
+
+/**
+ * Resolves the root URL of the Radicle HTTP API based on the endpoint configured
+ * in the settings.
+ *
+ * @example getApiRoot() // http://127.0.0.1:8080/api/v1
+ *
+ * @returns a string value representing the root URL of the Radicle API.
+ * @throws if no endpoint to the Radicle HTTP API is configured in the settings
+ */
+export function getApiRoot(): string {
+  const apiRootPath = '/api/v1' // should we be fetching and using NodeRoot.path instead?
+  const httpEndpoint =
+    getConfig('radicle.advanced.httpApiEndpoint') ?? '<radicle.advanced.httpApiEndpoint>'
+  const apiRoot = `${httpEndpoint.replace(/\/$/, '')}${apiRootPath}`
+
+  return apiRoot
+}
+
+interface RadicleProject {
+  id: string
+  name: string
+  description: string
+  trackings?: number
+}
+
+export async function fetchRadicleProjects(options?: {
+  onError?: (requestUrl: string) => unknown
+}): Promise<RadicleProject[] | undefined> {
+  const apiProjects = `${getApiRoot()}/projects`
+
+  try {
+    const projects = (await (await fetch(apiProjects)).json()) as RadicleProject[]
+
+    return projects
+  } catch (error) {
+    const errorMsg =
+      typeof error === 'string'
+        ? error
+        : error instanceof Error
+        ? error.message
+        : `Failed fetching Radicle projects`
+
+    log(errorMsg, 'error', `Fetching "${apiProjects}"...`)
+    options?.onError?.(apiProjects)
+
+    return undefined
+  }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './api'
 export * from './command'
 export * from './config'
 export * from './configWatcher'

--- a/src/ux/HttpApiConnection.ts
+++ b/src/ux/HttpApiConnection.ts
@@ -1,6 +1,6 @@
 import { window } from 'vscode'
 import { fetch } from 'undici'
-import { getConfig } from '../helpers'
+import { getApiRoot } from '../helpers'
 import { log } from '../utils'
 
 /**
@@ -13,26 +13,22 @@ import { log } from '../utils'
 export async function validateHttpApiEndpointConnection(
   options: { minimizeUserNotifications: boolean } = { minimizeUserNotifications: false },
 ): Promise<boolean> {
-  const endpoint = getConfig('radicle.advanced.httpApiEndpoint')
-
-  if (!endpoint) {
-    throw new Error('No endpoint to the Radicle HTTP API is set')
-  }
+  const apiRoot = getApiRoot()
 
   try {
-    const response = await fetch(endpoint)
+    const response = await fetch(apiRoot)
 
     if (!response.ok) {
       throw new Error(
-        `Received non-OK status "${response.status}" from Radicle HTTP API at "${endpoint}"`,
+        `Received non-OK status "${response.status}" from Radicle HTTP API at "${apiRoot}"`,
       )
     }
 
     if (((await response.json()) as { service?: string }).service !== 'radicle-httpd') {
-      throw new Error(`HTTP API at "${endpoint}" doesn't seem to be a Radicle API`)
+      throw new Error(`HTTP API at "${apiRoot}" doesn't seem to be a Radicle API`)
     }
 
-    const msg = `Connected with Radicle HTTP API at "${endpoint}"`
+    const msg = `Connected with Radicle HTTP API at "${apiRoot}"`
     log(msg, 'info')
     !options.minimizeUserNotifications && window.showInformationMessage(msg)
 
@@ -44,11 +40,11 @@ export async function validateHttpApiEndpointConnection(
         : error instanceof Error
         ? error.message
         : `Failed fetching Radicle HTTP API root`
-    log(errorMsg, 'error', `Fetching "${endpoint}"...`)
+    log(errorMsg, 'error', `Fetching "${apiRoot}"...`)
 
     !options.minimizeUserNotifications &&
       window.showErrorMessage(`Failed establishing connection with Radicle HTTP API \
-      at "${endpoint}. \
+      at "${apiRoot}. \
       Please ensure that "radicle-httpd" is already running and the address to the API's \
       root endpoint is correctly set in the extension's settings."`)
 


### PR DESCRIPTION
Previously the default http endpoint config value would include the `/api/v1` path. That should be abstracted as it is an application implementation detail. This commit changes the default config value to not include it.
Additionally applies some light refactoring and clean-up to api- related code.

Relates to #26 

Signed-off-by: Konstantinos Maninakis <maninak@protonmail.com>