### PR TITLE
fix(auth): ask user for and use alias when creating new identity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,8 @@
     "icons",
     "changelog",
     "readme",
-    "ci"
+    "ci",
+    "auth"
   ],
   "conventionalCommits.gitmoji": false,
   "prettier.enable": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **commands:** replace pre-heartwood, now deprecated rad pull/push commands with fetch/announce across multiple UI locations ([#42](https://github.com/cytechmobile/radicle-vscode-extension/issues/42))
 - update from from old (seedling) to new (alien) Radicle logo and branding ([#56](https://github.com/cytechmobile/radicle-vscode-extension/issues/56))
+- **auth:** fix cration of new Radicle identity which now requires a mandatory alias ([#67](https://github.com/cytechmobile/radicle-vscode-extension/issues/67))
 
 ### 💅 Refactors
 


### PR DESCRIPTION
This patch hotfixes the issue by adding an additional user prompt, disregarding unhandled edge cases. An additional patch will be required to convert the prompt to a multi-step InputBox and properly fix the issue. Opting for this due to time constraints.

Closes partially #67