### PR TITLE
chore: set `npm.packageManager` to `"pnpm"`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "npm.packageManager": "npm",
+  "npm.packageManager": "pnpm",
   "markdown.experimental.copyFiles.destination": {
     "**/*": "assets/for-md/"
   },


### PR DESCRIPTION
I inferred that you want to run `pnpm` from https://github.com/cytechmobile/radicle-vscode-extension/blob/c0216c45b43444c589d95c638e090da7fe3ffd8b/package.json#L32

Also, the extension did not build for me with `npm`, but it did after making this change. See also https://github.com/microsoft/vscode/pull/100654