### PR TITLE
chore(repo): don't recommend deprecated vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "dbaeumer.vscode-eslint",
     "bradlc.vscode-tailwindcss",
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
     "antfu.iconify",
   ],
   // Please make sure you disable the following extensions *for this workspace*


### PR DESCRIPTION
This extension greets me with

> The "TypeScript Vue Plugin (Volar)" extension is no longer needed since v2. Please uninstall it.

everytime I start VSCode. It's deprecated, so why not remove it?