### PR TITLE
chore: add `--trace-deprecation` to `NODE_OPTIONS`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,9 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "preLaunchTask": "npm: dev",
       "postDebugTask": "Terminate All Tasks",
+      "env": {
+        "NODE_OPTIONS": "--trace-deprecation"
+      }
     },
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### 🏡 Chores
 
 - **scripts:** parallelize verifying extension and webview dependencies ([#108](https://github.com/cytechmobile/radicle-vscode-extension/pull/8), [#111](https://github.com/cytechmobile/radicle-vscode-extension/pull/111))
+- **dev:** configure "Develop Extension" launch configuration to show the stack trace in case of nodejs deprecation warning, helping pinpoint the roote cause ([#132](https://github.com/cytechmobile/radicle-vscode-extension/issues/132))
 
 ### 🤖 CI
 


### PR DESCRIPTION
This will produce stack traces in case some Node API gets deprecated. Without setting the option, no stack trace is printed, making these cases much harder to debug.

Closes cytechmobile/radicle-vscode-extension#130