### PR TITLE
test(e2e): onboarding tests

### DIFF
--- a/test/e2e/constants/config.ts
+++ b/test/e2e/constants/config.ts
@@ -11,3 +11,9 @@ export const e2eTestDirPath = join(__dirname, '..')
  * files outside of the e2e test directory.
  */
 export const rootDirPath = join(__dirname, '../../..')
+
+/**
+ * The path to the node home directory. This is where the Radicle node stores its
+ * configuration and data.
+ */
+export const nodeHomePath = process.env['RAD_HOME']

--- a/test/e2e/constants/config.ts
+++ b/test/e2e/constants/config.ts
@@ -17,3 +17,10 @@ export const rootDirPath = join(__dirname, '../../..')
  * configuration and data.
  */
 export const nodeHomePath = process.env['RAD_HOME']
+
+/**
+ * The path to a backup node home directory. This is used to store the original
+ * node home directory for tests that require the original path to be moved or
+ * modified.
+ */
+export const backupNodeHomePath = `${nodeHomePath}.backup`

--- a/test/e2e/helpers/actions.ts
+++ b/test/e2e/helpers/actions.ts
@@ -1,0 +1,15 @@
+import type { Workbench } from 'wdio-vscode-service'
+
+/**
+ * Opens the Radicle view container in the sidebar, by clicking the radicle button in the
+ * activity bar.
+ */
+export async function openRadicleViewContainer(workbench: Workbench) {
+  const activityBar = workbench.getActivityBar()
+  await activityBar.wait()
+
+  const radicleViewControl = await activityBar.getViewControl('Radicle')
+  await radicleViewControl?.wait()
+
+  await radicleViewControl?.openView()
+}

--- a/test/e2e/helpers/assertions.ts
+++ b/test/e2e/helpers/assertions.ts
@@ -6,19 +6,23 @@ import type { Workbench } from 'wdio-vscode-service'
  * considered the default state when the workspace is open with a git and rad initialized
  * repository.
  */
-export async function expectCliCommandsAndPatchesToBeVisible(workbench: Workbench) {
+export async function expectStandardSidebarViewsToBeVisible(workbench: Workbench) {
   const sidebarView = workbench.getSideBar().getContent()
   await sidebarView.wait()
 
-  await browser.waitUntil(async () => {
-    let sectionsFound = false
-    try {
-      await sidebarView.getSection('CLI COMMANDS')
-      await sidebarView.getSection('PATCHES')
-      sectionsFound = true
-      // eslint-disable-next-line prettier-vue/prettier
-    } catch { }
+  await browser.waitUntil(
+    async () => {
+      try {
+        await Promise.all([
+          sidebarView.getSection('CLI COMMANDS'),
+          sidebarView.getSection('PATCHES'),
+        ])
 
-    return sectionsFound
-  })
+        return true
+      } catch {
+        return false
+      }
+    },
+    { timeoutMsg: 'expected the standard sidebar views to be visible' },
+  )
 }

--- a/test/e2e/helpers/assertions.ts
+++ b/test/e2e/helpers/assertions.ts
@@ -1,0 +1,24 @@
+import { browser } from '@wdio/globals'
+import type { Workbench } from 'wdio-vscode-service'
+
+/**
+ * Asserts that the CLI Commands and Patches sections are visible in the sidebar. This is
+ * considered the default state when the workspace is open with a git and rad initialized
+ * repository.
+ */
+export async function expectCliCommandsAndPatchesToBeVisible(workbench: Workbench) {
+  const sidebarView = workbench.getSideBar().getContent()
+  await sidebarView.wait()
+
+  await browser.waitUntil(async () => {
+    let sectionsFound = false
+    try {
+      await sidebarView.getSection('CLI COMMANDS')
+      await sidebarView.getSection('PATCHES')
+      sectionsFound = true
+      // eslint-disable-next-line prettier-vue/prettier
+    } catch { }
+
+    return sectionsFound
+  })
+}

--- a/test/e2e/helpers/queries.ts
+++ b/test/e2e/helpers/queries.ts
@@ -1,0 +1,21 @@
+import type { Workbench } from 'wdio-vscode-service'
+
+/**
+ * Retrieves the welcome text content from the first section in the sidebar view.
+ *
+ * @example await getFirstWelcomeViewText(workbench) // ["Welcome to Radicle!", "Get started by ..."]
+ *
+ * @returns The text content found as an array of strings split by newlines. If no content is
+ * found, an empty array.
+ */
+export async function getFirstWelcomeViewText(workbench: Workbench) {
+  const sidebarView = workbench.getSideBar().getContent()
+  await sidebarView.wait()
+
+  const welcomeText =
+    (await (
+      await (await sidebarView.getSections())[0]?.findWelcomeContent()
+    )?.getTextSections()) ?? []
+
+  return welcomeText
+}

--- a/test/e2e/specs/onboarding.spec.ts
+++ b/test/e2e/specs/onboarding.spec.ts
@@ -4,7 +4,7 @@ import type { Workbench } from 'wdio-vscode-service'
 import { $, cd } from 'zx'
 import type * as VsCode from 'vscode'
 import isEqual from 'lodash/isEqual'
-import { expectCliCommandsAndPatchesToBeVisible } from '../helpers/assertions'
+import { expectStandardSidebarViewsToBeVisible } from '../helpers/assertions'
 import { openRadicleViewContainer } from '../helpers/actions'
 import { getFirstWelcomeViewText } from '../helpers/queries'
 import { e2eTestDirPath, nodeHomePath } from '../constants/config'
@@ -127,11 +127,11 @@ describe('Onboarding Flow', () => {
       })
     })
 
-    it('shows the CLI Commands and Patches sections', async () => {
+    it('shows the standard sidebar views', async () => {
       const sidebarView = workbench.getSideBar().getContent()
       await sidebarView.wait()
 
-      await expectCliCommandsAndPatchesToBeVisible(workbench)
+      await expectStandardSidebarViewsToBeVisible(workbench)
     })
   })
 })

--- a/test/e2e/specs/onboarding.spec.ts
+++ b/test/e2e/specs/onboarding.spec.ts
@@ -7,7 +7,7 @@ import isEqual from 'lodash/isEqual'
 import { expectStandardSidebarViewsToBeVisible } from '../helpers/assertions'
 import { openRadicleViewContainer } from '../helpers/actions'
 import { getFirstWelcomeViewText } from '../helpers/queries'
-import { e2eTestDirPath, nodeHomePath } from '../constants/config'
+import { backupNodeHomePath, e2eTestDirPath, nodeHomePath } from '../constants/config'
 
 describe('Onboarding Flow', () => {
   let workbench: Workbench
@@ -17,15 +17,8 @@ describe('Onboarding Flow', () => {
   })
 
   describe('VS Code, *before* Radicle is installed,', () => {
-    const tempPathToNodeHome = `${nodeHomePath}.temp`
-
-    before(async () => {
-      // Simulate radicle "not being installed" by renaming the node home directory
-      await $`mv ${nodeHomePath} ${tempPathToNodeHome}`
-    })
-
     after(async () => {
-      await $`mv ${tempPathToNodeHome} ${nodeHomePath}`
+      await $`mv ${backupNodeHomePath} ${nodeHomePath}`
       await workbench.executeCommand('Developer: Reload Window')
     })
 

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -1,7 +1,12 @@
 import path from 'node:path'
 import { $ } from 'zx'
 import type { Options } from '@wdio/types'
-import { e2eTestDirPath, rootDirPath } from './constants/config'
+import {
+  backupNodeHomePath,
+  e2eTestDirPath,
+  nodeHomePath,
+  rootDirPath,
+} from './constants/config'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const packageJson = require('../../package.json')
@@ -55,5 +60,10 @@ export const config: Options.Testrunner = {
   },
   onPrepare: async () => {
     await $`mkdir -p ${path.join(rootDirPath, 'node_modules/.cache/wdio')}`
+  },
+  onWorkerStart: async (_cid, _caps, specs) => {
+    if (specs.some((spec) => spec.includes('onboarding.spec.ts'))) {
+      await $`mv ${nodeHomePath} ${backupNodeHomePath}`
+    }
   },
 }


### PR DESCRIPTION
Prerequisite #169 

Closes #163 

- Tests the welcome screen shown if the rad binary isn't found (e.g. before Radicle is installed)
  - Radicle not being installed is simulated by moving the `.radicle` from it's default location
- Removes `browser.pause` (used on some flaky tests) in favour of using `browser.waitUntil` (asynchronous assertions). This should reduce overall flakiness when adding new tests to the suite.
- Extracts some common helper functions to separate files