### PR TITLE
test(e2e): settings tests

### DIFF
--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   test-e2e:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/test/e2e/helpers/actions.ts
+++ b/test/e2e/helpers/actions.ts
@@ -13,3 +13,13 @@ export async function openRadicleViewContainer(workbench: Workbench) {
 
   await radicleViewControl?.openView()
 }
+
+export async function closeRadicleViewContainer(workbench: Workbench) {
+  const activityBar = workbench.getActivityBar()
+  await activityBar.wait()
+
+  const radicleViewControl = await activityBar.getViewControl('Radicle')
+  await radicleViewControl?.wait()
+
+  await radicleViewControl?.closeView()
+}

--- a/test/e2e/helpers/actions.ts
+++ b/test/e2e/helpers/actions.ts
@@ -1,4 +1,12 @@
 import type { Workbench } from 'wdio-vscode-service'
+import { Key } from 'webdriverio'
+
+export async function clearInput(input: WebdriverIO.Element) {
+  // Focus the input, sometimes clicking doesn't work
+  await input.setValue('')
+  await browser.keys([Key.Ctrl, 'a'])
+  await browser.keys(Key.Backspace)
+}
 
 /**
  * Opens the Radicle view container in the sidebar, by clicking the radicle button in the

--- a/test/e2e/helpers/assertions.ts
+++ b/test/e2e/helpers/assertions.ts
@@ -2,13 +2,13 @@ import { browser } from '@wdio/globals'
 import type { OutputView, Workbench } from 'wdio-vscode-service'
 
 /**
- * Asserts the output view contains the expected text.
+ * Asserts the Output Panel contains the expected text.
  */
 export async function expectOutputToContain(outputView: OutputView, expected: string) {
   await browser.waitUntil(
     async () => {
       /**
-       * The text in the output console is split by newlines, which can be affected by the size
+       * The text in the Output Panel is split by newlines, which can be affected by the size
        * of the window. To avoid this, we join the text into a single string.
        */
       const joinedText = (await outputView.getText()).join('')

--- a/test/e2e/helpers/assertions.ts
+++ b/test/e2e/helpers/assertions.ts
@@ -23,6 +23,11 @@ export async function expectStandardSidebarViewsToBeVisible(workbench: Workbench
         return false
       }
     },
-    { timeoutMsg: 'expected the standard sidebar views to be visible' },
+    {
+      timeoutMsg: 'expected the standard sidebar views to be visible',
+      // TODO: zac fine tune these (globally?)
+      timeout: 20000,
+      interval: 500,
+    },
   )
 }

--- a/test/e2e/helpers/assertions.ts
+++ b/test/e2e/helpers/assertions.ts
@@ -1,5 +1,25 @@
 import { browser } from '@wdio/globals'
-import type { Workbench } from 'wdio-vscode-service'
+import type { OutputView, Workbench } from 'wdio-vscode-service'
+
+/**
+ * Asserts the output view contains the expected text.
+ */
+export async function expectOutputToContain(outputView: OutputView, expected: string) {
+  await browser.waitUntil(
+    async () => {
+      /**
+       * The text in the output console is split by newlines, which can be affected by the size
+       * of the window. To avoid this, we join the text into a single string.
+       */
+      const joinedText = (await outputView.getText()).join('')
+
+      return joinedText.includes(expected)
+    },
+    {
+      timeoutMsg: `expected the output text to contain "${expected}"`,
+    },
+  )
+}
 
 /**
  * Asserts that the CLI Commands and Patches sections are visible in the sidebar. This is
@@ -23,11 +43,6 @@ export async function expectStandardSidebarViewsToBeVisible(workbench: Workbench
         return false
       }
     },
-    {
-      timeoutMsg: 'expected the standard sidebar views to be visible',
-      // TODO: zac fine tune these (globally?)
-      timeout: 20000,
-      interval: 500,
-    },
+    { timeoutMsg: 'expected the standard sidebar views to be visible' },
   )
 }

--- a/test/e2e/specs/onboarding.spec.ts
+++ b/test/e2e/specs/onboarding.spec.ts
@@ -5,7 +5,7 @@ import { $, cd } from 'zx'
 import type * as VsCode from 'vscode'
 import isEqual from 'lodash/isEqual'
 import { expectStandardSidebarViewsToBeVisible } from '../helpers/assertions'
-import { openRadicleViewContainer } from '../helpers/actions'
+import { closeRadicleViewContainer, openRadicleViewContainer } from '../helpers/actions'
 import { getFirstWelcomeViewText } from '../helpers/queries'
 import { backupNodeHomePath, e2eTestDirPath, nodeHomePath } from '../constants/config'
 
@@ -14,6 +14,10 @@ describe('Onboarding Flow', () => {
 
   before(async () => {
     workbench = await browser.getWorkbench()
+  })
+
+  after(async () => {
+    await closeRadicleViewContainer(workbench)
   })
 
   describe('VS Code, *before* Radicle is installed,', () => {

--- a/test/e2e/specs/settings.spec.ts
+++ b/test/e2e/specs/settings.spec.ts
@@ -74,8 +74,7 @@ describe('Settings', () => {
     })
 
     // This functionality does not seem to work
-    // eslint-disable-next-line max-len
-    it.skip('recognizes if the directory is created *after* the setting is updated', async () => {
+    it.skip('recognizes if the directory is created *after* the setting is set', async () => {
       await setTextSettingValue(pathToRadBinarySetting, tempNodeHomePath)
 
       await expectRadBinaryNotFoundToBeVisible(workbench)
@@ -140,8 +139,7 @@ describe('Settings', () => {
     })
 
     // This functionality does not seem to work
-    // eslint-disable-next-line max-len
-    it.skip('recognizes if the directory is created *after* the setting is updated', async () => {
+    it.skip('recognizes if the directory is created *after* the setting is set', async () => {
       await outputView.clearText()
 
       await setTextSettingValue(pathToNodeHomeSetting, tempNodeHomePath)

--- a/test/e2e/specs/settings.spec.ts
+++ b/test/e2e/specs/settings.spec.ts
@@ -1,0 +1,137 @@
+import { browser } from '@wdio/globals'
+import type { Setting, SettingsEditor, Workbench } from 'wdio-vscode-service'
+import isEqual from 'lodash/isEqual'
+import { Key } from 'webdriverio'
+import { $ } from 'zx'
+import { getFirstWelcomeViewText } from '../helpers/queries'
+import { expectCliCommandsAndPatchesToBeVisible } from '../helpers/assertions'
+import { closeRadicleViewContainer, openRadicleViewContainer } from '../helpers/actions'
+import { nodeHomePath } from '../constants/config'
+
+describe('Settings', () => {
+  let workbench: Workbench
+  let settings: SettingsEditor
+
+  before(async () => {
+    workbench = await browser.getWorkbench()
+    settings = await workbench.openSettings()
+    await openRadicleViewContainer(workbench)
+    await expectCliCommandsAndPatchesToBeVisible(workbench)
+  })
+
+  after(async () => {
+    await closeRadicleViewContainer(workbench)
+  })
+
+  describe('VS Code, when updating the "Path to Rad Binary" setting,', () => {
+    let pathToRadBinarySetting: Setting
+
+    before(async () => {
+      pathToRadBinarySetting = await settings.findSetting(
+        'Path To Rad Binary',
+        'Radicle',
+        'Advanced',
+      )
+    })
+
+    afterEach(async () => {
+      await clearTextSetting(pathToRadBinarySetting)
+
+      await expectCliCommandsAndPatchesToBeVisible(workbench)
+    })
+
+    it('warns the user if the rad binary is not found', async () => {
+      await browser.pause(1000)
+      await setTextSettingValue(pathToRadBinarySetting, '/tmp')
+
+      await expectRadBinaryNotFoundToBeVisible(workbench)
+    })
+
+    it('recognizes the rad binary when a valid path is specified', async () => {
+      const tempNodeHomePath = `${nodeHomePath}.temp`
+      await $`cp -r ${nodeHomePath} ${tempNodeHomePath}`
+
+      await setTextSettingValue(pathToRadBinarySetting, `/tmp`)
+
+      await expectRadBinaryNotFoundToBeVisible(workbench)
+
+      await setTextSettingValue(pathToRadBinarySetting, `${tempNodeHomePath}/bin/rad`)
+
+      await expectCliCommandsAndPatchesToBeVisible(workbench)
+
+      await $`rm -rf ${tempNodeHomePath}`
+    })
+
+    // This functionality does not seem to work
+    // eslint-disable-next-line max-len
+    it.skip('recognizes if the directory is created *after* the setting is updated', async () => {
+      const tempNodeHomePath = `${nodeHomePath}.temp`
+
+      await setTextSettingValue(pathToRadBinarySetting, tempNodeHomePath)
+
+      await expectRadBinaryNotFoundToBeVisible(workbench)
+
+      await $`cp -r ${nodeHomePath} ${tempNodeHomePath}`
+
+      await expectCliCommandsAndPatchesToBeVisible(workbench)
+
+      await clearTextSetting(pathToRadBinarySetting)
+
+      await $`rm -rf ${tempNodeHomePath}`
+    })
+  })
+})
+
+async function expectRadBinaryNotFoundToBeVisible(workbench: Workbench) {
+  await browser.waitUntil(
+    async () => {
+      const welcomeText = await getFirstWelcomeViewText(workbench)
+
+      console.log({ welcomeText })
+
+      return isEqual(welcomeText, [
+        /* eslint-disable max-len */
+        'Failed resolving the Radicle CLI binary.',
+        "Please ensure it is installed on your machine and either that it is globally accessible in the shell as `rad` or that its path is correctly defined in the extension's settings.",
+        "Please expect the extention's capabilities to remain severely limited until this issue is resolved.",
+        /* eslint-enable max-len */
+      ])
+    },
+    {
+      timeoutMsg: 'expected the rad binary not found message to be visible',
+      // TODO: zac fine tune these (globally?)
+      timeout: 20000,
+      interval: 500,
+    },
+  )
+}
+
+/**
+ * Workaround to get the value of a `TextSetting`.
+ * The `getValue` method of a `TextSetting` seems to be wrongly implemented and returns null.
+ */
+async function getTextSettingValue(setting: Setting) {
+  return await setting.textSetting$.getValue()
+}
+
+async function setTextSettingValue(setting: Setting, value: string) {
+  await clearTextSetting(setting)
+  await setting.setValue(value)
+}
+
+async function clearTextSetting(setting: Setting) {
+  /**
+   * `.setValue('')` updates the value of the input but does not trigger an
+   * update in the extension. Not sure if this is a bug in the extension, vscode, or
+   * webdriverio.
+   *
+   * The following is a workaround that does trigger an update in the extension.
+   */
+  if ((await getTextSettingValue(setting)) === '') {
+    return
+  }
+
+  await setting.textSetting$.click()
+  await browser.keys([Key.Ctrl, 'a'])
+  await browser.keys(Key.Backspace)
+}

--- a/test/e2e/specs/settings.spec.ts
+++ b/test/e2e/specs/settings.spec.ts
@@ -73,7 +73,7 @@ describe('Settings', () => {
       await $`rm -rf ${tempNodeHomePath}`
     })
 
-    // This functionality does not seem to work
+    // TODO: Unskip when #172 covered by this case is fixed
     it.skip('recognizes if the directory is created *after* the setting is set', async () => {
       await setTextSettingValue(pathToRadBinarySetting, tempNodeHomePath)
 
@@ -88,10 +88,11 @@ describe('Settings', () => {
   })
 
   /**
-   * In Linux CI:
-   * - The extension is having issues resolving the correct node home directory (RAD_HOME).
-   * - Even when node home is set explicitly in the settings, the extension incorrectly reports it
-   *   as non-authenticated.
+   * These tests is skipped on Linux CI because the extension is having issues resolving the correct
+   * node home directory.
+   *
+   * TODO: Figure out why the extension is having issues resolving the correct node home directory
+   * on Linux CI.
    */
   // eslint-disable-next-line max-len
   describe('VS Code, when updating the "Path to Radicle to Node Home" setting, @skipLinuxCI', () => {
@@ -138,7 +139,7 @@ describe('Settings', () => {
       await $`rm -rf ${tempNodeHomePath}`
     })
 
-    // This functionality does not seem to work
+    // TODO: Unskip when #172 covered by this case is fixed
     it.skip('recognizes if the directory is created *after* the setting is set', async () => {
       await outputView.clearText()
 

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -18,6 +18,17 @@ if (!process.env['CI']) {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 const vscodeVersion = (packageJson.engines.vscode as string).replace(/^\^/, '')
 
+const skipTestsGrep = []
+
+switch (process.platform) {
+  case 'darwin':
+    skipTestsGrep.push('@skipMacOSCI')
+    break
+  case 'linux':
+    skipTestsGrep.push('@skipLinuxCI')
+    break
+}
+
 // TODO: Bump webdriverio to v9 once wdio-vscode-service supports it
 // Relevant PR: https://github.com/webdriverio-community/wdio-vscode-service/pull/130
 // Relevant Issue: https://github.com/webdriverio-community/wdio-vscode-service/issues/140
@@ -60,6 +71,8 @@ export const config: Options.Testrunner = {
   mochaOpts: {
     ui: 'bdd',
     timeout: 60000,
+    grep: skipTestsGrep.length > 0 ? skipTestsGrep.join('|') : undefined,
+    invert: true,
   },
   onPrepare: async () => {
     await $`mkdir -p ${path.join(rootDirPath, 'node_modules/.cache/wdio')}`

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import path, { sep } from 'node:path'
 import { $ } from 'zx'
 import type { Options } from '@wdio/types'
 import {
@@ -29,6 +29,13 @@ switch (process.platform) {
     break
 }
 
+const orderedSpecPaths = ['./specs/onboarding.spec.ts', './specs/settings.spec.ts'].map(
+  (specPath) => specPath.replace('/', sep),
+)
+const specsToExcludeFromGlob = orderedSpecPaths.map((specPath) =>
+  specPath.split(sep).at(-1)?.replace('.spec.ts', ''),
+)
+
 // TODO: Bump webdriverio to v9 once wdio-vscode-service supports it
 // Relevant PR: https://github.com/webdriverio-community/wdio-vscode-service/pull/130
 // Relevant Issue: https://github.com/webdriverio-community/wdio-vscode-service/issues/140
@@ -40,10 +47,7 @@ export const config: Options.Testrunner = {
       transpileOnly: true,
     },
   },
-  specs: [
-    ['./specs/onboarding.spec.ts', './specs/settings.spec.ts'],
-    './specs/**/!(onboarding|settings).spec.ts',
-  ],
+  specs: [orderedSpecPaths, `./specs/**/!(${specsToExcludeFromGlob.join('|')}).spec.ts`],
   maxInstances: 10,
   capabilities: [
     {

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -29,7 +29,10 @@ export const config: Options.Testrunner = {
       transpileOnly: true,
     },
   },
-  specs: ['./specs/**/*.ts'],
+  specs: [
+    ['./specs/onboarding.spec.ts', './specs/settings.spec.ts'],
+    './specs/**/!(onboarding|settings).spec.ts',
+  ],
   maxInstances: 10,
   capabilities: [
     {

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -64,7 +64,7 @@ export const config: Options.Testrunner = {
     },
   ],
   logLevel: 'warn',
-  waitforTimeout: 10000,
+  waitforTimeout: 20000,
   services: [['vscode', { cachePath: path.join(rootDirPath, 'node_modules/.cache/wdio') }]],
   framework: 'mocha',
   reporters: ['spec'],


### PR DESCRIPTION
Prerequisite #162 

- Tests the "Path to Rad Binary" and "Path to Node Home" extension settings

Notes:
- The tests that verify that the extension recognizes paths that are created **after** the setting is updated are implemented but marked to be skipped by the runner. As discussed, this functionality *should* work but doesn't at the moment
- The "Path to Node Home" tests are skipped on the Linux CI, as there seems to be an issue where the extension does not correctly pick up the initial node home path (from the `RAD_HOME` env var)