### PR TITLE
test(e2e): cover picking up a rad binary created after the extension loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **aliases:** cover node-alias resolution with unit tests (address-book cache seeding, refresh-and-persist, and mapping a patch author to its alias) and an e2e assertion that a patch author renders its alias, sourced from the local node's address book, instead of a node id
 - **clone:** cover the cloneable-repo cache and picker with unit tests (version-adaptive pagination, the once-a-day refresh throttle, the full-on-disk vs capped-in-memory split, live list growth, and offline error handling) and rework the clone e2e for the new live-updating picker
 - **e2e:** silence the git and `rad` command output that the test runner echoed during patch setup, de-noising the e2e logs (failures still surface their output)
+- **onboarding:** cover, with an e2e test, that the extension picks up a rad binary created at a path whose parent directory did not exist when the extension loaded, without a window reload (via the fallback poll)
 
 ### 📖 Documentation
 

--- a/test/e2e/specs/onboarding.spec.ts
+++ b/test/e2e/specs/onboarding.spec.ts
@@ -1,5 +1,6 @@
 import type * as VsCode from 'vscode'
 import type { Workbench } from 'wdio-vscode-service'
+import { join } from 'node:path'
 import { browser, expect } from '@wdio/globals'
 import { $, cd } from 'zx'
 import { openRadicleViewContainer } from '../helpers/actions'
@@ -123,7 +124,76 @@ describe('Onboarding Flow', () => {
       await expectStandardSidebarViewsToBeVisible(workbench)
     })
   })
+
+  // Regression for #172: Node's file watchers can't fire for a path whose parent dir didn't
+  // exist when we started watching (e.g. rad installed _after_ the extension loaded), so the
+  // extension falls back to polling. Point it at a binary under a not-yet-existing dir, then
+  // create the binary there and assert it gets picked up with no window reload.
+  describe('Radicle CLI appearing at a path that did not exist when the extension loaded,', () => {
+    const nodeHome = process.env['RAD_E2E_NODE_HOME'] ?? ''
+    const realRadCli = join(nodeHome, 'bin', 'rad')
+    const lateBinDir = join(nodeHome, 'late-bin')
+    const lateRadCli = join(lateBinDir, 'rad')
+
+    before(async () => {
+      await setPathToRadBinaryConfig(lateRadCli)
+    })
+
+    after(async () => {
+      await setPathToRadBinaryConfig(undefined)
+      await $`rm -rf ${lateBinDir}`
+    })
+
+    it('reports the CLI as unresolvable while the configured path is still missing', async () => {
+      await openRadicleViewContainer(workbench)
+
+      await browser.waitUntil(
+        async () =>
+          (await getFirstWelcomeViewText(workbench)).some((text) =>
+            text.includes('Failed resolving the Radicle CLI binary'),
+          ),
+        {
+          timeoutMsg:
+            'expected the "CLI unresolvable" guide while the configured path is missing',
+        },
+      )
+    })
+
+    it('picks up the CLI once it appears there, with no reload (via the fallback poll)', async () => {
+      await $`mkdir -p ${lateBinDir}`
+      await $`cp ${realRadCli} ${lateRadCli}`
+      await $`chmod +x ${lateRadCli}`
+
+      // the poll re-checks every few seconds, so allow comfortably more than one interval
+      await browser.waitUntil(
+        async () =>
+          (await getFirstWelcomeViewText(workbench)).some((text) =>
+            text.includes('Failed resolving the Radicle CLI binary'),
+          ) === false,
+        {
+          timeout: 20_000,
+          timeoutMsg:
+            'expected the extension to pick up the newly-created rad binary via its poll',
+        },
+      )
+    })
+  })
 })
+
+async function setPathToRadBinaryConfig(path: string | undefined): Promise<void> {
+  await browser.executeWorkbench(
+    async (vscode: typeof VsCode, configuredPath: string | undefined) => {
+      await vscode.workspace
+        .getConfiguration()
+        .update(
+          'radicle.advanced.pathToRadBinary',
+          configuredPath,
+          vscode.ConfigurationTarget.Global,
+        )
+    },
+    path,
+  )
+}
 
 async function initGitRepo() {
   const workspacePath = process.env['RAD_E2E_WORKSPACE'] ?? ''


### PR DESCRIPTION
Adds the missing regression coverage for #172, whose fix (the fallback poll for a CLI binary appearing at a path whose parent dir didn't exist at load) already landed in #178. The test points the `pathToRadBinary` setting at a binary under a not-yet-existing dir, so only the poll (not a VS Code file watcher) can detect it, then creates the binary and asserts the extension picks it up with no window reload. Verified locally (onboarding spec: 9 passing).

Closes #172
