### PR TITLE
test(e2e): fix flaky checked-out-marker assertion by matching row class precisely

### DIFF
--- a/test/e2e/specs/patch-details.spec.ts
+++ b/test/e2e/specs/patch-details.spec.ts
@@ -520,10 +520,15 @@ function getPatchStatusFromRadCli(workspacePath: string, patchId: string) {
  * fails on `.panel-header`). Remove when the service compares versions numerically.
  */
 function getPatchItemXpath(label: string) {
-  // tree rows cloned into VS Code's sticky-scroll container are excluded: they linger
-  // hidden after an expanded row scrolls or collapses, shadowing the real row
+  // Match the `monaco-list-row` class as a whole space-delimited token, not a substring:
+  // a bare `contains(@class, "monaco-list-row")` also matches the `monaco-list-rows` wrapper
+  // that holds every row, whose combined text spans all rows. That made "row X shows/hides the
+  // marker" assertions read a sibling's marker off the wrapper and flake.
+  //
+  // Tree rows cloned into VS Code's sticky-scroll container are excluded: they linger hidden
+  // after an expanded row scrolls or collapses, shadowing the real row.
   return (
-    `//div[contains(@class, "sidebar")]//div[contains(@class, "monaco-list-row")]` +
+    `//div[contains(@class, "sidebar")]//div[contains(concat(" ", normalize-space(@class), " "), " monaco-list-row ")]` +
     `[not(ancestor::div[contains(@class, "monaco-tree-sticky-container")])]` +
     `[.//span[contains(text(), "${label}")]]`
   )
@@ -679,14 +684,6 @@ async function switchToPatchDetailWebview(workbench: Workbench) {
 }
 
 describe('Patch state synchronization,', () => {
-  // Runs locally but skipped on CI: the "moves the checked-out marker" test is chronically flaky
-  // there due to VS Code sidebar render-timing (the marker repaints later than the wait window),
-  // and it mutates git state (seeds a branch), so mocha retries are not safe either. The "sorts"
-  // test reuses that branch/patch, so it is skipped alongside it to keep the pair coherent.
-  // Tracked in https://github.com/maninak/radicle-vscode-extension/issues/195 . Linux CI covers
-  // the rest of this spec; macOS CI skips the spec whole (see test/e2e/wdio.conf.ts).
-  const itSkippedOnCi = process.env['CI'] ? it.skip : it
-
   const secondPatchTitle = 'feat: second patch'
   const thirdPatchTitle = 'feat: third patch'
   let workbench: Workbench
@@ -781,7 +778,7 @@ describe('Patch state synchronization,', () => {
     })
   })
 
-  itSkippedOnCi('moves the checked-out marker when checking out another patch', async () => {
+  it('moves the checked-out marker when checking out another patch', async () => {
     secondPatchId = await seedExtraPatch(workspacePath, 'feat/second', secondPatchTitle)
     await workbench.executeCommand('Refresh All Patch Data')
 
@@ -807,33 +804,30 @@ describe('Patch state synchronization,', () => {
     await webview.close()
   })
 
-  itSkippedOnCi(
-    'sorts an out-of-band updated patch to the top, listing it exactly once',
-    async () => {
-      await seedExtraPatch(workspacePath, 'feat/third', thirdPatchTitle)
-      await workbench.executeCommand('Refresh All Patch Data')
+  it('sorts an out-of-band updated patch to the top, listing it exactly once', async () => {
+    await seedExtraPatch(workspacePath, 'feat/third', thirdPatchTitle)
+    await workbench.executeCommand('Refresh All Patch Data')
 
-      await expect(await findPatchItem(thirdPatchTitle)).toBeDisplayed()
-      await expectPatchItemToBeListedAbove(thirdPatchTitle, secondPatchTitle)
+    await expect(await findPatchItem(thirdPatchTitle)).toBeDisplayed()
+    await expectPatchItemToBeListedAbove(thirdPatchTitle, secondPatchTitle)
 
-      // grow the older patch (the second) with a new revision, out of band
-      await zx`git checkout feat/second`
-      await zx`echo "more" >> second.txt`
-      await zx`git add second.txt`
-      await zx`git commit -m 'grows the second patch' --no-gpg-sign`
-      await zx`git push rad HEAD:patches/${secondPatchId}`
+    // grow the older patch (the second) with a new revision, out of band
+    await zx`git checkout feat/second`
+    await zx`echo "more" >> second.txt`
+    await zx`git add second.txt`
+    await zx`git commit -m 'grows the second patch' --no-gpg-sign`
+    await zx`git push rad HEAD:patches/${secondPatchId}`
 
-      await workbench.executeCommand('Refresh All Patch Data')
+    await workbench.executeCommand('Refresh All Patch Data')
 
-      await expectPatchItemToBeListedAbove(secondPatchTitle, thirdPatchTitle)
+    await expectPatchItemToBeListedAbove(secondPatchTitle, thirdPatchTitle)
 
-      const rowsWithSecondPatchTitle = (await snapshotSidebarRowTexts()).filter((text) =>
-        text.includes(secondPatchTitle),
-      )
+    const rowsWithSecondPatchTitle = (await snapshotSidebarRowTexts()).filter((text) =>
+      text.includes(secondPatchTitle),
+    )
 
-      expect(rowsWithSecondPatchTitle.length).toBe(1)
-    },
-  )
+    expect(rowsWithSecondPatchTitle.length).toBe(1)
+  })
 })
 
 /** Creates one more patch off of master, on `branchName`, and returns its id. */
@@ -944,10 +938,6 @@ async function expectPatchItemCheckedOutMarker(label: string, isShown: boolean) 
       return false
     },
     {
-      // patch checkouts trigger several successive re-renders, each involving a `rad cob show`
-      // that can transiently fail and retry if it races the checkout's own node lock; under
-      // heavy parallel CI load that chain occasionally needs more than a few seconds to settle
-      timeout: 30_000,
       timeoutMsg: `expected the item labeled "${label}" to ${
         isShown ? 'show' : 'not show'
       } the checked-out marker. Last visible row text: "${lastRowText}"`,

--- a/test/e2e/specs/patch-details.spec.ts
+++ b/test/e2e/specs/patch-details.spec.ts
@@ -165,6 +165,10 @@ describe("Patch details, of a patch on the user's own rad-initialized repo,", ()
     )
 
     expect(getPatchStatusFromRadCli(workspacePath, patchId)).toBe('draft')
+
+    // the mutation's "Updated and announced patch" toast would otherwise linger into (and
+    // intercept a click meant for a webview button in) the next test
+    await dismissAllNotifications()
   })
 
   it('persists patch title and description edits submitted from within the webview', async () => {
@@ -191,6 +195,8 @@ describe("Patch details, of a patch on the user's own rad-initialized repo,", ()
     const patchShowOutput = (await zx`rad patch show ${patchId}`).stdout
 
     expect(patchShowOutput).toContain(webviewEditedPatchTitle)
+
+    await dismissAllNotifications()
   })
 
   it("lists a patch's changed files, diffed via git, and opens a diff editor", async () => {
@@ -604,6 +610,17 @@ async function switchBackToMainFrame() {
 }
 
 /**
+ * Dismisses any visible VS Code notification toasts. A patch mutation (status change, title
+ * or description edit) triggers an "Updated and announced patch" toast that otherwise lingers
+ * into the next test and can intercept a click meant for a webview button behind it.
+ */
+async function dismissAllNotifications() {
+  await browser.executeWorkbench(async (vscode: typeof VsCode) => {
+    await vscode.commands.executeCommand('notifications.clearAll')
+  })
+}
+
+/**
  * Opens (or reveals) the details webview of the patch item labeled `label`.
  *
  * An already open (but possibly backgrounded, and thus iframe-less) panel is revealed by
@@ -773,9 +790,7 @@ describe('Patch state synchronization,', () => {
     await zx`git checkout -- hello.txt`
 
     // dismiss the asserted error notification so it cannot obscure later interactions
-    await browser.executeWorkbench(async (vscode: typeof VsCode) => {
-      await vscode.commands.executeCommand('notifications.clearAll')
-    })
+    await dismissAllNotifications()
   })
 
   it('moves the checked-out marker when checking out another patch', async () => {

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -70,19 +70,9 @@ const allE2eSpecs = [
 ]
 // Optionally run a subset locally, e.g. `RAD_E2E_ONLY_SPEC=patch-details pnpm test:e2e`
 const onlySpecFilter = process.env['RAD_E2E_ONLY_SPEC']
-const selectedSpecs = onlySpecFilter
+const e2eSpecs = onlySpecFilter
   ? allE2eSpecs.filter((spec) => spec.includes(onlySpecFilter))
   : allE2eSpecs
-
-// patch-details.spec.ts is chronically flaky specifically on macOS CI runners: their slower
-// Electron renderer intermittently stops repainting the Patches sidebar partway through the
-// suite, cascading the whole worker. It's a render-timing/runner issue, not app logic, and it
-// passes reliably locally and on Linux CI (which retains full coverage). Skip it on macOS CI.
-// Tracked in https://github.com/maninak/radicle-vscode-extension/issues/195
-const isMacosCi = Boolean(process.env['CI']) && process.platform === 'darwin'
-const e2eSpecs = isMacosCi
-  ? selectedSpecs.filter((spec) => !spec.includes('patch-details.spec.ts'))
-  : selectedSpecs
 
 /** Specs that mutate the network, so they get their own worker node + httpd. */
 const networkMutatingSpecs = ['clone.spec.ts', 'patch-details.spec.ts']


### PR DESCRIPTION
Closes #195

The flake was a test bug, not app or CI timing. `getPatchItemXpath` matched the tree row class with `contains(@class, "monaco-list-row")`, a substring match that also matched the `.monaco-list-rows` wrapper spanning every row's combined text. The one assertion that checks a row does NOT show the marker while a sibling DOES read the sibling's marker off that wrapper and flaked whenever wdio's `$$` happened to resolve the wrapper before the real row.

Fixed by matching the class as a whole space-delimited token. Removed the CI skips, the 30s timeout bump, and the macOS whole-spec skip that had accumulated around this.

Verified locally: reproduced the flake on the full parallel suite (~50% fail rate), then 5/5 clean full-suite runs after the fix.