### PR TITLE
fix(patch-detail): bound long review bodies and stop hiding summary-less review comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🩹 Fixes
 
+- **patch-detail:** bound long review bodies in the Activity timeline with the same expand/collapse treatment long comments get, and show a review's comment even when it carries no summary line (it used to render nothing at all)
 - **patches:** show the Patches view's "N · Updated ..." header promptly, including "0 · ..." for a repo with no patches. It could previously stay blank until a later refresh when the view was hidden as patches first loaded
 
 ### ☑️ Tests

--- a/src/webviews/src/components/PatchDetailActivity.vue
+++ b/src/webviews/src/components/PatchDetailActivity.vue
@@ -359,18 +359,33 @@ function togglePreviewMarkdown() {
           <span :title="event.revision.author.id" class="font-mono">
             {{ getIdentityAliasOrId(event.review.author) }}
           </span>
-          <template v-if="event.review.summary">
-            <details v-if="event.review.summary && event.review.comment">
+          <template v-if="event.review.summary || event.review.comment">
+            <details
+              v-if="
+                event.review.comment ||
+                (event.review.summary?.length ?? 0) > maxCharsForUntruncatedMdText
+              "
+            >
               <summary
                 title="Click to Expand/Collapse"
                 class="mt-1 max-w-prose break-words font-mono text-sm"
               >
-                {{ event.review.summary }}
+                {{ truncateMarkdown(event.review.summary ?? event.review.comment ?? '') }}
               </summary>
-              <Markdown :source="event.review.comment" class="mt-[0.25em] text-sm" />
+              <p
+                v-if="(event.review.summary?.length ?? 0) > maxCharsForUntruncatedMdText"
+                class="max-w-prose break-words font-mono text-sm"
+              >
+                {{ event.review.summary }}
+              </p>
+              <Markdown
+                v-if="event.review.comment"
+                :source="event.review.comment"
+                class="mt-[0.25em] text-sm"
+              />
             </details>
             <p
-              v-else-if="event.review.summary && !event.review.comment"
+              v-else-if="event.review.summary"
               class="mb-[-0.2em] mt-1 max-w-prose break-words font-mono text-sm"
             >
               {{ event.review.summary }}

--- a/test/unit/specs/patchData.spec.ts
+++ b/test/unit/specs/patchData.spec.ts
@@ -126,6 +126,29 @@ describe('loadPatches() from the local node', () => {
   // A redacted review serializes as `null` in the reviews map (like redacted revisions do);
   // it must be skipped, not crash the whole listing (the same failure class this branch set
   // out to fix).
+  it('maps a review faithfully: verdict, summary, and author survive', () => {
+    // regression guard for GH #206: real `rad cob show` review shape (verified against all
+    // 156 reviews in heartwood's storage on 2026-07-09) must map without losing the verdict
+    execRadMock.mockImplementation((args: string[]) => {
+      if (args.includes('list')) {
+        return { stdout: patchId }
+      }
+      if (args.includes('show')) {
+        return { stdout: patchCobFixture({ reviews: { r1: reviewFixture() } }) }
+      }
+
+      return { errorCode: 1 }
+    })
+
+    const { data } = loadPatches('rad:z123')
+
+    const review = data?.[0]?.revisions[0]?.reviews[0]
+
+    expect(review?.verdict).toBe('accept')
+    expect(review?.summary).toBe('lgtm')
+    expect(review?.author.id).toBe(`did:key:${authorA}`)
+  })
+
   it('skips a redacted (null) review instead of failing the load', () => {
     execRadMock.mockImplementation((args: string[]) => {
       if (args.includes('list')) {


### PR DESCRIPTION
Relates to #206
Closes #208